### PR TITLE
ENH: Drop Inputs.Include/Exclude

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -50,20 +50,7 @@
       "type": "string"
     },
     "Input": {
-      "type": "object",
-        "anyOf": [ 
-          {
-            "properties": {
-              "Include": {
-                  "$ref":  "#/definitions/DatasetInputs/inputKeywords"
-              },
-              "Exclude": {
-                "$ref":  "#/definitions/DatasetInputs/inputKeywords"
-              }
-            }
-          },
-          {"$ref":  "#/definitions/DatasetInputs/inputKeywords"}
-        ]
+      "$ref":  "#/definitions/DatasetInputs/inputKeywords"
     },
     "Nodes": {
       "type": "array",


### PR DESCRIPTION
These were included in a spec example, but never defined or implemented in PyBIDS.