### PR TITLE
ENH: Transformations.Instructions may not be objects

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -82,8 +82,7 @@
             "properties": {
               "Transformer": {"type": "string"},
               "Instructions": {
-                "type": "array",
-                "items": {"type": "object"}
+                "type": "array"
               }
             }
           },


### PR DESCRIPTION
PyBIDS transformations are objects. Somebody could write a spec that accepts strings directly.