### PR TITLE
[FIX] make mask an object and remove confounds

### DIFF
--- a/model-narps_smdl.json
+++ b/model-narps_smdl.json
@@ -34,7 +34,13 @@
         ]
       },
       "Model": {
-        "X": ["gain_trials", "loss_trials", "gain", "loss", "demeaned_RT", 1]
+        "X": ["gain_trials", "loss_trials", "gain", "loss", "demeaned_RT", 1],
+        "Options":{
+          "Mask": {
+            "desc": "brain",
+            "suffix": "mask"
+          }
+        }
       },
       "DummyContrasts": {
         "Conditions": ["gain", "loss"],
@@ -45,7 +51,7 @@
       "Level": "Subject",
       "Name": "subject",
       "GroupBy": ["subject", "contrast"],
-      "Model": {"X": [1], "Type": "Meta"},
+      "Model": {"X": [1], "Type": "meta"},
       "DummyContrasts": {
         "Test": "t"
       }

--- a/schema.json
+++ b/schema.json
@@ -104,16 +104,13 @@
                 "properties": {
                     "HighPassFilterCutoffSecs": {"type": "number"},
                     "LowPassFilterCutoffSecs": {"type": "number"},
-                    "Confounds": {
-                       "type": "array",
-                       "items": {"type": "string"}
-                    },
                     "ReplaceVariables": {
                       "type": "object",
                       "additionalProperties": true
                     },
                     "Mask": {
-                      "type": "string"
+                      "type": "object",
+                      "additionalProperties": true
                     },
                     "Aggregate": {
                       "type": "string",


### PR DESCRIPTION
- make node.model.options.mask an object: modified "narps" with example from the spec to validate  
- remove node.model.options.confounds confounds: does not exist in the spec
